### PR TITLE
zip mapping file for faster upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,35 @@ Used to automatically upload ProGuard mapping files to [Bugfender](https://bugfe
 
 ## Usage
 
-*Note:* The plugin requires `com.android.tools.build:gradle` in version at least `4.1` to work properly.
-
 Add the plugin to your *app* `build.gradle` file and configure it with the Symbols Upload Token, obtained from your Bugfender dashboard.
 
-```
+After that, every assembled app bundle will automatically send mapping file to Bugfender.
+
+### Kotlin Gradle configuration (`app/build.gradle.kts` file)
+
+Add the Bugfender plugin to the `plugins` section and create a new `bugfender` section, like this:
+
+```kotlin
 plugins {
-    id "com.bugfender.upload-mapping" version "1.1.1"
+    id("com.android.application")
+    // you may have other plugins here
+    id("com.bugfender.upload-mapping") version "1.2.0"
+}
+
+bugfender {
+    symbolicationToken("<your_token_here>")
+}
+```
+
+### Groovy Gradle configuration (`app/build.gradle` file)
+
+Add the Bugfender plugin to the `plugins` section and create a new `bugfender` section, like this:
+
+```groovy
+plugins {
+    id "com.android.application"
+    // you may have other plugins here
+    id "com.bugfender.upload-mapping" version "1.2.0"
 }
 
 bugfender {
@@ -19,16 +41,54 @@ bugfender {
 }
 ```
 
-After that, every assembled app bundle will automatically send mapping file to Bugfender.
+Note: in older project configurations, it's possible this file it's not under an `app` directory.
 
-Local development
-=================
+### Bugfender On-Premises
+
+If you're using a Bugfender instance other than `dashboard.bugfender.com`, you will need to specify the URL of your instance:
+
+In `app/build.gradle.kts` (Kotlin):
+
+```kotlin
+bugfender {
+    symbolicationToken("<your_token_here>")
+    symbolicationURL("https://bugfender.yourcompany.com/")
+}
+```
+
+Or, if you have a `app/build.gradle` (Groovy):
+
+```groovy
+bugfender {
+    symbolicationToken "<your_token_here>"
+    symbolicationURL "https://bugfender.yourcompany.com/"
+}
+```
+
+### Troubleshooting
+
+#### Error message `org.gradle.api.plugins.UnknownPluginException: Plugin [id: 'com.bugfender.upload-mapping', version: 'XXX'] was not found...`
+
+You may need to configure the plugin repositories in your `settings.gradle.kts` or `settings.gradle` file.
+Add `gradlePluginPortal()` to the `pluginManagement` > `repositories` section, like this:
+
+```kotlin
+pluginManagement {
+    repositories {
+        // you may have other repos here
+        gradlePluginPortal()
+    }
+}
+```
+
+
+# Contributing
 
 To use a local version that's not published to the maven central.
 
 * Publish it to a local maven repository with `gradle publishToMavenLocal` task.
 * In the test project, add `mavenLocal` to repositories in `settings.gradle`:
-```
+```groovy
 pluginManagement {
     repositories {
         mavenLocal()

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bugfender {
 }
 ```
 
-Note: in older project configurations, it's possible this file it's not under an `app` directory.
+Note: in older project configurations, it's possible this file is not under an `app` directory.
 
 ### Bugfender On-Premises
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.30'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
     id "com.gradle.plugin-publish" version "0.16.0" // For publishing on https://plugins.gradle.org/ -> use publishPlugins task
     id 'maven-publish' // For publishing on local maven repository (for development purposes) -> use publishToMavenLocal task
 }
@@ -10,7 +10,7 @@ repositories {
 }
 
 group 'com.bugfender'
-version '1.1.2'
+version '1.2.0'
 
 compileKotlin {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -25,12 +25,11 @@ repositories {
 dependencies {
     compileOnly "com.android.tools.build:gradle:7.0.2"
 
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.30'
-    implementation "com.squareup.okhttp3:okhttp:4.9.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
 
     testImplementation "com.android.tools.build:gradle:7.0.2"
     testImplementation "io.mockk:mockk:1.12.0"
-    testImplementation "com.squareup.okhttp3:mockwebserver:4.9.1"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0'
 }

--- a/src/main/kotlin/com/bugfender/UploadMappingPlugin.kt
+++ b/src/main/kotlin/com/bugfender/UploadMappingPlugin.kt
@@ -19,7 +19,7 @@ class UploadMappingPlugin : Plugin<Project> {
                     project.logger.debug("[Bugfender] Attempting to apply plugin to {}", variant.name)
 
                     if (!variant.buildType.isMinifyEnabled) {
-                        project.logger.lifecycle("[Bugfender] Not applying to {}: minification is disabled", variant.name)
+                        project.logger.debug("[Bugfender] Not applying to {}: minification is disabled", variant.name)
                         return@configureEach
                     }
 

--- a/src/main/kotlin/com/bugfender/UploadMappingTask.kt
+++ b/src/main/kotlin/com/bugfender/UploadMappingTask.kt
@@ -1,11 +1,10 @@
 package com.bugfender
 
 import com.android.build.gradle.api.ApplicationVariant
-import okhttp3.MediaType.Companion.toMediaType
+import com.bugfender.okhttp3.ZipFileRequestBody
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.asRequestBody
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.internal.provider.MissingValueException
@@ -13,9 +12,9 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.time.Duration
 
+
 abstract class UploadMappingTask : DefaultTask() {
     companion object {
-        private val FILE_MIME_TYPE = "text/plain; charset=utf-8".toMediaType()
         private val httpClient = OkHttpClient.Builder()
           .connectTimeout(Duration.ofSeconds(600))
           .readTimeout(Duration.ofSeconds(600))
@@ -58,13 +57,12 @@ abstract class UploadMappingTask : DefaultTask() {
             this.logger.debug("No mapping files found for {}", this.name)
             return
         }
-        val firstFile = files.first()
 
         val reqBody = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart("version", this.variant.versionName)
             .addFormDataPart("build", this.variant.versionCode.toString())
-            .addFormDataPart("file", firstFile.name, firstFile.asRequestBody(FILE_MIME_TYPE))
+            .addFormDataPart("file", "gradle-mappings.zip", ZipFileRequestBody(files))
             .build()
         val request = requestBuilder.post(reqBody).build()
         try {

--- a/src/main/kotlin/com/bugfender/okhttp3/ZipFileRequestBody.kt
+++ b/src/main/kotlin/com/bugfender/okhttp3/ZipFileRequestBody.kt
@@ -1,0 +1,27 @@
+package com.bugfender.okhttp3
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class ZipFileRequestBody(val contents: Set<File>) : RequestBody() {
+  companion object {
+    private val FILE_MIME_TYPE = "application/zip".toMediaType()
+  }
+
+  override fun contentType() = FILE_MIME_TYPE
+
+  override fun writeTo(sink: BufferedSink) {
+    val zos = ZipOutputStream(sink.outputStream())
+    contents.forEach {
+      zos.putNextEntry(ZipEntry(it.name))
+      Files.copy(it.toPath(), zos)
+      zos.closeEntry()
+    }
+    zos.finish() // finishes writing without closing. okhttp3 docs do not state anything, but examples show no close statements and closing causes an exception
+  }
+}

--- a/src/test/kotlin/com/bugfender/UploadMappingTaskTest.kt
+++ b/src/test/kotlin/com/bugfender/UploadMappingTaskTest.kt
@@ -66,7 +66,7 @@ class UploadMappingTaskTest {
         assertArrayEquals(arrayOf("build", "file", "version"), values.keys.sorted().toTypedArray())
         assertEquals("1.0-test", values["version"])
         assertEquals("1", values["build"])
-        assertEquals("TESTFILECONTENT", values["file"])
+        assert(values["file"]!!.startsWith("PK")) // zip file
     }
 
     @Test


### PR DESCRIPTION
Zips the mapping file while uploading, for significantly faster uploads.

Also dependency update.

Demo, mapping file uploaded to Bugfender's internal storage matches the original mapping file:
![Screenshot 2024-01-30 at 12 21 25](https://github.com/bugfender/gradle-mapping-upload/assets/864706/63790340-44bb-4f60-9756-b69e11514d72)
